### PR TITLE
Allow both types of PromisesObjC imports

### DIFF
--- a/ios/RNGoogleCast/api/RNGCRemoteMediaClient.m
+++ b/ios/RNGoogleCast/api/RNGCRemoteMediaClient.m
@@ -6,7 +6,12 @@
 #import "../types/RCTConvert+GCKRemoteMediaClient.m"
 #import "RNGCRequest.h"
 #import <Foundation/Foundation.h>
-#import <PromisesObjC/FBLPromises.h>
+
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
 
 @implementation RNGCRemoteMediaClient {
   bool hasListeners;


### PR DESCRIPTION
### Background
In case when the client's CocoaPods configuration is using dynamic frameworks (`use_frameworks!` in Podfile), then the project is not buildable because `react-native-google-cast` cannot find `PromisesObjC/FBLPromises.h`
![Screenshot 2021-01-26 at 12 40 07](https://user-images.githubusercontent.com/41613812/105840057-146b8780-5fdb-11eb-9b8a-409eb367906e.png)
This behaviour can be tested on the main branch using the iOS playground project:
1. Set `use_frameworks! :linkage => :static` in [Podfile](https://github.com/react-native-google-cast/react-native-google-cast/blob/main/playground/ios/Podfile).
2. Disable Flipper in Podfile by commenting on the lines.
3. Run `pod install`.
4. Build the project.
5. Notice the error. 

The other libraries allow both types of `PromisesObjC` imports:
- https://github.com/firebase/firebase-ios-sdk/pull/4624
- https://github.com/firebase/firebase-ios-sdk/blob/14764b8d60a6ad023d8fa5b7f81d42378d92e6fe/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsSingleOperationPromiseCache.m#L19

### What has been done?
1. I have used the same approach as Firebase has done https://github.com/firebase/firebase-ios-sdk/pull/4624.

### How to test the changes?
Without `use_frameworks!` in Podfile:
1. Build the iOS Playgrounds project. No errors should come up.

With `use_frameworks!` in Podfile:
1. Update iOS Playgrounds project's Podfile by adding `use_frameworks! :linkage => :static` on the top of file.
2. Disable Flipper in Podfile by commenting on the lines.
3. Run `pod install`.
4. Build the iOS Playgrounds project. No errors should come up. 