### PR TITLE
Fix linker warnings from iOS react-native-google-cast

### DIFF
--- a/ios/RNGoogleCast.xcodeproj/project.pbxproj
+++ b/ios/RNGoogleCast.xcodeproj/project.pbxproj
@@ -126,6 +126,46 @@
 		91829AE1227E1D9900906C0C /* RNGoogleCastButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNGoogleCastButton.h; path = RNGoogleCast/components/RNGoogleCastButton.h; sourceTree = SOURCE_ROOT; };
 		91829AE2227E1D9900906C0C /* RNGoogleCastButtonManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RNGoogleCastButtonManager.m; path = RNGoogleCast/components/RNGoogleCastButtonManager.m; sourceTree = SOURCE_ROOT; };
 		91EB35C72283E67100ABE8E1 /* RCTConvert+ISO8601Date.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+ISO8601Date.m"; sourceTree = "<group>"; };
+		F5A8B31225CDE17B001CD915 /* RCTConvert+GCKCastSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKCastSession.h"; sourceTree = "<group>"; };
+		F5A8B37F25CDE68B001CD915 /* RCTConvert+GCKMediaLoadRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaLoadRequest.h"; sourceTree = "<group>"; };
+		F5A8B38125CDE6EF001CD915 /* RCTConvert+GCKMediaQueueContainerMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaQueueContainerMetadata.h"; sourceTree = "<group>"; };
+		F5A8B38225CDE72E001CD915 /* RCTConvert+GCKMediaQueueContainerType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaQueueContainerType.h"; sourceTree = "<group>"; };
+		F5A8B38425CDE90A001CD915 /* RCTConvert+GCKMediaQueueData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaQueueData.h"; sourceTree = "<group>"; };
+		F5A8B38525CDE916001CD915 /* RCTConvert+GCKMediaQueueType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaQueueType.h"; sourceTree = "<group>"; };
+		F5A8B38625CDE929001CD915 /* RCTConvert+GCKRemoteMediaClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKRemoteMediaClient.h"; sourceTree = "<group>"; };
+		F5A8B38725CDE932001CD915 /* RCTConvert+GCKActiveInputStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKActiveInputStatus.h"; sourceTree = "<group>"; };
+		F5A8B38825CDE93B001CD915 /* RCTConvert+GCKAdBreakClipInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKAdBreakClipInfo.h"; sourceTree = "<group>"; };
+		F5A8B38925CDE945001CD915 /* RCTConvert+GCKAdBreakInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKAdBreakInfo.h"; sourceTree = "<group>"; };
+		F5A8B38A25CDE94E001CD915 /* RCTConvert+GCKAdBreakStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKAdBreakStatus.h"; sourceTree = "<group>"; };
+		F5A8B38B25CDE956001CD915 /* RCTConvert+GCKApplicationMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKApplicationMetadata.h"; sourceTree = "<group>"; };
+		F5A8B38C25CDE962001CD915 /* RCTConvert+GCKCastState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKCastState.h"; sourceTree = "<group>"; };
+		F5A8B38D25CDE96D001CD915 /* RCTConvert+GCKColor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKColor.h"; sourceTree = "<group>"; };
+		F5A8B38E25CDE9C0001CD915 /* RCTConvert+GCKDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKDevice.h"; sourceTree = "<group>"; };
+		F5A8B38F25CDE9CC001CD915 /* RCTConvert+GCKHLSSegmentFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKHLSSegmentFormat.h"; sourceTree = "<group>"; };
+		F5A8B39025CDE9D5001CD915 /* RCTConvert+GCKImage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKImage.h"; sourceTree = "<group>"; };
+		F5A8B39125CDE9E0001CD915 /* RCTConvert+GCKMediaInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaInformation.h"; sourceTree = "<group>"; };
+		F5A8B39225CDE9E8001CD915 /* RCTConvert+GCKMediaMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaMetadata.h"; sourceTree = "<group>"; };
+		F5A8B39325CDE9F1001CD915 /* RCTConvert+GCKMediaMetadataType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaMetadataType.h"; sourceTree = "<group>"; };
+		F5A8B39425CDE9F8001CD915 /* RCTConvert+GCKMediaPlayerIdleReason.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaPlayerIdleReason.h"; sourceTree = "<group>"; };
+		F5A8B39525CDE9FF001CD915 /* RCTConvert+GCKMediaPlayerState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaPlayerState.h"; sourceTree = "<group>"; };
+		F5A8B39625CDEA05001CD915 /* RCTConvert+GCKMediaQueueItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaQueueItem.h"; sourceTree = "<group>"; };
+		F5A8B39725CDEA10001CD915 /* RCTConvert+GCKMediaRepeatMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaRepeatMode.h"; sourceTree = "<group>"; };
+		F5A8B39825CDEA19001CD915 /* RCTConvert+GCKMediaResumeState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaResumeState.h"; sourceTree = "<group>"; };
+		F5A8B39925CDEA21001CD915 /* RCTConvert+GCKMediaSeekOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaSeekOptions.h"; sourceTree = "<group>"; };
+		F5A8B39A25CDEA2B001CD915 /* RCTConvert+GCKMediaStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaStatus.h"; sourceTree = "<group>"; };
+		F5A8B39B25CDEA33001CD915 /* RCTConvert+GCKMediaStreamType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaStreamType.h"; sourceTree = "<group>"; };
+		F5A8B39C25CDEA3F001CD915 /* RCTConvert+GCKMediaTextTrackStyle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaTextTrackStyle.h"; sourceTree = "<group>"; };
+		F5A8B39D25CDEA5B001CD915 /* RCTConvert+GCKMediaTextTrackStyleEdgeType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaTextTrackStyleEdgeType.h"; sourceTree = "<group>"; };
+		F5A8B39E25CDEA64001CD915 /* RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.h"; sourceTree = "<group>"; };
+		F5A8B39F25CDEA6D001CD915 /* RCTConvert+GCKMediaTextTrackStyleWindowType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaTextTrackStyleWindowType.h"; sourceTree = "<group>"; };
+		F5A8B3A025CDEA76001CD915 /* RCTConvert+GCKMediaTextTrackStyleFontStyle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaTextTrackStyleFontStyle.h"; sourceTree = "<group>"; };
+		F5A8B3A125CDEA7F001CD915 /* RCTConvert+GCKMediaTextTrackSubtype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaTextTrackSubtype.h"; sourceTree = "<group>"; };
+		F5A8B3A225CDEA87001CD915 /* RCTConvert+GCKMediaTrack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaTrack.h"; sourceTree = "<group>"; };
+		F5A8B3A325CDEA8E001CD915 /* RCTConvert+GCKMediaTrackType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKMediaTrackType.h"; sourceTree = "<group>"; };
+		F5A8B3A425CDEA9D001CD915 /* RCTConvert+GCKStandbyStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKStandbyStatus.h"; sourceTree = "<group>"; };
+		F5A8B3A525CDEAA4001CD915 /* RCTConvert+GCKVideoInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKVideoInfo.h"; sourceTree = "<group>"; };
+		F5A8B3A625CDEAAB001CD915 /* RCTConvert+GCKVideoInfoHDRType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GCKVideoInfoHDRType.h"; sourceTree = "<group>"; };
+		F5A8B3A725CDEAB3001CD915 /* RCTConvert+ISO8601Date.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+ISO8601Date.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -197,45 +237,85 @@
 		91D99D8A231A73270081468C /* types */ = {
 			isa = PBXGroup;
 			children = (
+				F5A8B31225CDE17B001CD915 /* RCTConvert+GCKCastSession.h */,
 				914BA2BD25BF7545001FFA5E /* RCTConvert+GCKCastSession.m */,
+				F5A8B37F25CDE68B001CD915 /* RCTConvert+GCKMediaLoadRequest.h */,
 				914BA2BF25BF7545001FFA5E /* RCTConvert+GCKMediaLoadRequest.m */,
+				F5A8B38125CDE6EF001CD915 /* RCTConvert+GCKMediaQueueContainerMetadata.h */,
 				914BA2C125BF7545001FFA5E /* RCTConvert+GCKMediaQueueContainerMetadata.m */,
+				F5A8B38225CDE72E001CD915 /* RCTConvert+GCKMediaQueueContainerType.h */,
 				914BA2BE25BF7545001FFA5E /* RCTConvert+GCKMediaQueueContainerType.m */,
+				F5A8B38425CDE90A001CD915 /* RCTConvert+GCKMediaQueueData.h */,
 				914BA2BC25BF7545001FFA5E /* RCTConvert+GCKMediaQueueData.m */,
+				F5A8B38525CDE916001CD915 /* RCTConvert+GCKMediaQueueType.h */,
 				914BA2C025BF7545001FFA5E /* RCTConvert+GCKMediaQueueType.m */,
+				F5A8B38625CDE929001CD915 /* RCTConvert+GCKRemoteMediaClient.h */,
 				914BA2C225BF7545001FFA5E /* RCTConvert+GCKRemoteMediaClient.m */,
+				F5A8B38725CDE932001CD915 /* RCTConvert+GCKActiveInputStatus.h */,
 				914932D0231C6EA8001AE93B /* RCTConvert+GCKActiveInputStatus.m */,
+				F5A8B38825CDE93B001CD915 /* RCTConvert+GCKAdBreakClipInfo.h */,
 				91829AAF227E1D5F00906C0C /* RCTConvert+GCKAdBreakClipInfo.m */,
+				F5A8B38925CDE945001CD915 /* RCTConvert+GCKAdBreakInfo.h */,
 				91829AB5227E1D5F00906C0C /* RCTConvert+GCKAdBreakInfo.m */,
+				F5A8B38A25CDE94E001CD915 /* RCTConvert+GCKAdBreakStatus.h */,
 				91829AA9227E1D5E00906C0C /* RCTConvert+GCKAdBreakStatus.m */,
+				F5A8B38B25CDE956001CD915 /* RCTConvert+GCKApplicationMetadata.h */,
 				914932D2231D7554001AE93B /* RCTConvert+GCKApplicationMetadata.m */,
+				F5A8B38C25CDE962001CD915 /* RCTConvert+GCKCastState.h */,
 				9143E4D4231B1659008A23D9 /* RCTConvert+GCKCastState.m */,
+				F5A8B38D25CDE96D001CD915 /* RCTConvert+GCKColor.h */,
 				914932D4231E7502001AE93B /* RCTConvert+GCKColor.m */,
+				F5A8B38E25CDE9C0001CD915 /* RCTConvert+GCKDevice.h */,
 				914932CE231C6AA5001AE93B /* RCTConvert+GCKDevice.m */,
+				F5A8B38F25CDE9CC001CD915 /* RCTConvert+GCKHLSSegmentFormat.h */,
 				91829AB6227E1D5F00906C0C /* RCTConvert+GCKHLSSegmentFormat.m */,
+				F5A8B39025CDE9D5001CD915 /* RCTConvert+GCKImage.h */,
 				91829AA2227E1D5E00906C0C /* RCTConvert+GCKImage.m */,
+				F5A8B39125CDE9E0001CD915 /* RCTConvert+GCKMediaInformation.h */,
 				91829ABA227E1D5F00906C0C /* RCTConvert+GCKMediaInformation.m */,
+				F5A8B39225CDE9E8001CD915 /* RCTConvert+GCKMediaMetadata.h */,
 				91829AA3227E1D5E00906C0C /* RCTConvert+GCKMediaMetadata.m */,
+				F5A8B39325CDE9F1001CD915 /* RCTConvert+GCKMediaMetadataType.h */,
 				91829AC2227E1D6000906C0C /* RCTConvert+GCKMediaMetadataType.m */,
+				F5A8B39425CDE9F8001CD915 /* RCTConvert+GCKMediaPlayerIdleReason.h */,
 				91829AB0227E1D5F00906C0C /* RCTConvert+GCKMediaPlayerIdleReason.m */,
+				F5A8B39525CDE9FF001CD915 /* RCTConvert+GCKMediaPlayerState.h */,
 				91829AAD227E1D5E00906C0C /* RCTConvert+GCKMediaPlayerState.m */,
+				F5A8B39625CDEA05001CD915 /* RCTConvert+GCKMediaQueueItem.h */,
 				91829ABB227E1D5F00906C0C /* RCTConvert+GCKMediaQueueItem.m */,
+				F5A8B39725CDEA10001CD915 /* RCTConvert+GCKMediaRepeatMode.h */,
 				91829AAB227E1D5E00906C0C /* RCTConvert+GCKMediaRepeatMode.m */,
+				F5A8B39825CDEA19001CD915 /* RCTConvert+GCKMediaResumeState.h */,
 				91829AB4227E1D5F00906C0C /* RCTConvert+GCKMediaResumeState.m */,
+				F5A8B39925CDEA21001CD915 /* RCTConvert+GCKMediaSeekOptions.h */,
 				91829AAA227E1D5E00906C0C /* RCTConvert+GCKMediaSeekOptions.m */,
+				F5A8B39A25CDEA2B001CD915 /* RCTConvert+GCKMediaStatus.h */,
 				91829AA6227E1D5E00906C0C /* RCTConvert+GCKMediaStatus.m */,
+				F5A8B39B25CDEA33001CD915 /* RCTConvert+GCKMediaStreamType.h */,
 				91829ABF227E1D6000906C0C /* RCTConvert+GCKMediaStreamType.m */,
+				F5A8B39C25CDEA3F001CD915 /* RCTConvert+GCKMediaTextTrackStyle.h */,
 				914932D6231E9977001AE93B /* RCTConvert+GCKMediaTextTrackStyle.m */,
+				F5A8B39D25CDEA5B001CD915 /* RCTConvert+GCKMediaTextTrackStyleEdgeType.h */,
 				914932D8231E9A07001AE93B /* RCTConvert+GCKMediaTextTrackStyleEdgeType.m */,
+				F5A8B39E25CDEA64001CD915 /* RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.h */,
 				914932DC231E9BBD001AE93B /* RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.m */,
+				F5A8B39F25CDEA6D001CD915 /* RCTConvert+GCKMediaTextTrackStyleWindowType.h */,
 				914932DA231E9B4E001AE93B /* RCTConvert+GCKMediaTextTrackStyleWindowType.m */,
+				F5A8B3A025CDEA76001CD915 /* RCTConvert+GCKMediaTextTrackStyleFontStyle.h */,
 				914932DE231E9CC0001AE93B /* RCTConvert+GCKMediaTextTrackStyleFontStyle.m */,
+				F5A8B3A125CDEA7F001CD915 /* RCTConvert+GCKMediaTextTrackSubtype.h */,
 				91829AB9227E1D5F00906C0C /* RCTConvert+GCKMediaTextTrackSubtype.m */,
+				F5A8B3A225CDEA87001CD915 /* RCTConvert+GCKMediaTrack.h */,
 				91829AA8227E1D5E00906C0C /* RCTConvert+GCKMediaTrack.m */,
+				F5A8B3A325CDEA8E001CD915 /* RCTConvert+GCKMediaTrackType.h */,
 				91829AA4227E1D5E00906C0C /* RCTConvert+GCKMediaTrackType.m */,
+				F5A8B3A425CDEA9D001CD915 /* RCTConvert+GCKStandbyStatus.h */,
 				91829AB2227E1D5F00906C0C /* RCTConvert+GCKStandbyStatus.m */,
+				F5A8B3A525CDEAA4001CD915 /* RCTConvert+GCKVideoInfo.h */,
 				91829AA7227E1D5E00906C0C /* RCTConvert+GCKVideoInfo.m */,
+				F5A8B3A625CDEAAB001CD915 /* RCTConvert+GCKVideoInfoHDRType.h */,
 				91829AB3227E1D5F00906C0C /* RCTConvert+GCKVideoInfoHDRType.m */,
+				F5A8B3A725CDEAB3001CD915 /* RCTConvert+ISO8601Date.h */,
 				91EB35C72283E67100ABE8E1 /* RCTConvert+ISO8601Date.m */,
 			);
 			path = types;

--- a/ios/RNGoogleCast/api/RNGCCastContext.m
+++ b/ios/RNGoogleCast/api/RNGCCastContext.m
@@ -1,6 +1,6 @@
 #import "RNGCCastContext.h"
 #import "RNGCSessionManager.h"
-#import "../types/RCTConvert+GCKCastState.m"
+#import "../types/RCTConvert+GCKCastState.h"
 
 #import <React/RCTBridge.h>
 #import <React/RCTConvert.h>

--- a/ios/RNGoogleCast/api/RNGCCastSession.m
+++ b/ios/RNGoogleCast/api/RNGCCastSession.m
@@ -1,9 +1,9 @@
 #import "RNGCCastSession.h"
-#import "../types/RCTConvert+GCKActiveInputStatus.m"
-#import "../types/RCTConvert+GCKApplicationMetadata.m"
-#import "../types/RCTConvert+GCKCastSession.m"
-#import "../types/RCTConvert+GCKDevice.m"
-#import "../types/RCTConvert+GCKStandbyStatus.m"
+#import "../types/RCTConvert+GCKActiveInputStatus.h"
+#import "../types/RCTConvert+GCKApplicationMetadata.h"
+#import "../types/RCTConvert+GCKCastSession.h"
+#import "../types/RCTConvert+GCKDevice.h"
+#import "../types/RCTConvert+GCKStandbyStatus.h"
 #import <Foundation/Foundation.h>
 
 @implementation RNGCCastSession {

--- a/ios/RNGoogleCast/api/RNGCRemoteMediaClient.m
+++ b/ios/RNGoogleCast/api/RNGCRemoteMediaClient.m
@@ -1,9 +1,9 @@
 #import "RNGCRemoteMediaClient.h"
-#import "../types/RCTConvert+GCKMediaInformation.m"
-#import "../types/RCTConvert+GCKMediaLoadRequest.m"
-#import "../types/RCTConvert+GCKMediaStatus.m"
-#import "../types/RCTConvert+GCKMediaTextTrackStyle.m"
-#import "../types/RCTConvert+GCKRemoteMediaClient.m"
+#import "../types/RCTConvert+GCKMediaInformation.h"
+#import "../types/RCTConvert+GCKMediaLoadRequest.h"
+#import "../types/RCTConvert+GCKMediaStatus.h"
+#import "../types/RCTConvert+GCKMediaTextTrackStyle.h"
+#import "../types/RCTConvert+GCKRemoteMediaClient.h"
 #import "RNGCRequest.h"
 #import <Foundation/Foundation.h>
 

--- a/ios/RNGoogleCast/api/RNGCSessionManager.m
+++ b/ios/RNGoogleCast/api/RNGCSessionManager.m
@@ -1,6 +1,6 @@
 #import "RNGCSessionManager.h"
 #import "RNGCRemoteMediaClient.h"
-#import "../types/RCTConvert+GCKCastSession.m"
+#import "../types/RCTConvert+GCKCastSession.h"
 #import <Foundation/Foundation.h>
 
 @implementation RNGCSessionManager {

--- a/ios/RNGoogleCast/types/RCTConvert+GCKActiveInputStatus.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKActiveInputStatus.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKActiveInputStatus_h
+#define RCTConvert_GCKActiveInputStatus_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKActiveInputStatus)
+
++ (nonnull id)fromGCKActiveInputStatus:(GCKActiveInputStatus)status;
+
+@end
+
+#endif /* RCTConvert_GCKActiveInputStatus_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKActiveInputStatus.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKActiveInputStatus.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKActiveInputStatus.h"
 
 @implementation RCTConvert (GCKActiveInputStatus)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakClipInfo.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakClipInfo.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKAdBreakClipInfo_h
+#define RCTConvert_GCKAdBreakClipInfo_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKAdBreakClipInfo)
+
++ (nonnull id)fromGCKAdBreakClipInfo:(nullable GCKAdBreakClipInfo *)info;
+
+@end
+
+#endif /* RCTConvert_GCKAdBreakClipInfo_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakClipInfo.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakClipInfo.m
@@ -1,6 +1,6 @@
-#import "RCTConvert+GCKHLSSegmentFormat.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKAdBreakClipInfo.h"
+
+#import "RCTConvert+GCKHLSSegmentFormat.h"
 
 @implementation RCTConvert (GCKAdBreakClipInfo)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakInfo.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakInfo.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKAdBreakInfo_h
+#define RCTConvert_GCKAdBreakInfo_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKAdBreakInfo)
+
++ (GCKAdBreakInfo *)GCKAdBreakInfo:(id)json;
++ (nonnull id)fromGCKAdBreakInfo:(nullable GCKAdBreakInfo *)info;
+
+@end
+
+#endif /* RCTConvert_GCKAdBreakInfo_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakInfo.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakInfo.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKAdBreakInfo.h"
 
 @implementation RCTConvert (GCKAdBreakInfo)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakStatus.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakStatus.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKAdBreakStatus_h
+#define RCTConvert_GCKAdBreakStatus_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKAdBreakStatus)
+
++ (nonnull id)fromGCKAdBreakStatus:(nullable GCKAdBreakStatus *)status;
+
+@end
+
+#endif /* RCTConvert_GCKAdBreakStatus_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakStatus.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKAdBreakStatus.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKAdBreakStatus.h"
 
 @implementation RCTConvert (GCKAdBreakStatus)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKApplicationMetadata.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKApplicationMetadata.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKApplicationMetadata_h
+#define RCTConvert_GCKApplicationMetadata_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKApplicationMetadata)
+
++ (nonnull id)fromGCKApplicationMetadata:(nullable GCKApplicationMetadata *)metadata;
+
+@end
+
+
+#endif /* RCTConvert_GCKApplicationMetadata_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKApplicationMetadata.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKApplicationMetadata.m
@@ -1,6 +1,6 @@
-#import "RCTConvert+GCKImage.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKApplicationMetadata.h"
+
+#import "RCTConvert+GCKImage.h"
 
 @implementation RCTConvert (GCKApplicationMetadata)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKCastSession.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKCastSession.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKCastSession_h
+#define RCTConvert_GCKCastSession_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKCastSession)
+
++ (nonnull id)fromGCKCastSession:(nullable GCKCastSession *)castSession;
+
+@end
+
+#endif /* RCTConvert_GCKCastSession_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKCastSession.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKCastSession.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKCastSession.h"
 
 @implementation RCTConvert (GCKCastSession)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKCastState.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKCastState.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKCastState_h
+#define RCTConvert_GCKCastState_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKCastState)
+
++ (nonnull id)fromGCKCastState:(GCKCastState)state;
+
+@end
+
+#endif /* RCTConvert_GCKCastState_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKCastState.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKCastState.h
@@ -6,6 +6,7 @@
 
 @interface RCTConvert (GCKCastState)
 
++ (GCKCastState)GCKCastState:(id)json;
 + (nonnull id)fromGCKCastState:(GCKCastState)state;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKCastState.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKCastState.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKCastState)
 
-+ (GCKCastState)GCKCastState:(id)json;
++ (GCKCastState)GCKCastState:(nullable id)json;
 + (nonnull id)fromGCKCastState:(GCKCastState)state;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKCastState.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKCastState.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKCastState.h"
 
 @implementation RCTConvert (GCKCastState)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKColor.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKColor.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKColor_h
+#define RCTConvert_GCKColor_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKColor)
+
++ (GCKColor *)GCKColor:(id)json;
++ (nonnull id)fromGCKColor:(nullable GCKColor *)color;
+
+@end
+
+#endif /* RCTConvert_GCKColor_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKColor.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKColor.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKColor.h"
 
 @implementation RCTConvert (GCKColor)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKDevice.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKDevice.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKDevice_h
+#define RCTConvert_GCKDevice_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKDevice)
+
++ (nonnull id)fromGCKDevice:(nullable GCKDevice *)device;
+
+@end
+
+#endif /* RCTConvert_GCKDevice_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKDevice.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKDevice.m
@@ -1,6 +1,6 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
-#import "RCTConvert+GCKImage.m"
+#import "RCTConvert+GCKDevice.h"
+
+#import "RCTConvert+GCKImage.h"
 
 @implementation RCTConvert (GCKDevice)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKHLSSegmentFormat.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKHLSSegmentFormat.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKHLSSegmentFormat_h
+#define RCTConvert_GCKHLSSegmentFormat_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKHLSSegmentFormat)
+
++ (nonnull id)fromGCKHLSSegmentFormat:(GCKHLSSegmentFormat)trackType;
+
+@end
+
+#endif /* RCTConvert_GCKHLSSegmentFormat_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKHLSSegmentFormat.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKHLSSegmentFormat.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKHLSSegmentFormat)
 
-+ (GCKHLSSegmentFormat)GCKHLSSegmentFormat:(id)json;
++ (GCKHLSSegmentFormat)GCKHLSSegmentFormat:(nullable id)json;
 + (nonnull id)fromGCKHLSSegmentFormat:(GCKHLSSegmentFormat)trackType;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKHLSSegmentFormat.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKHLSSegmentFormat.h
@@ -6,6 +6,7 @@
 
 @interface RCTConvert (GCKHLSSegmentFormat)
 
++ (GCKHLSSegmentFormat)GCKHLSSegmentFormat:(id)json;
 + (nonnull id)fromGCKHLSSegmentFormat:(GCKHLSSegmentFormat)trackType;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKHLSSegmentFormat.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKHLSSegmentFormat.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKHLSSegmentFormat.h"
 
 @implementation RCTConvert (GCKHLSSegmentFormat)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKImage.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKImage.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKImage_h
+#define RCTConvert_GCKImage_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKImage)
+
++ (GCKImage *)GCKImage:(id)json;
++ (nonnull id)fromGCKImage:(nullable GCKImage *)image;
+
+@end
+
+#endif /* RCTConvert_GCKImage_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKImage.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKImage.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKImage.h"
 
 @implementation RCTConvert (GCKImage)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaInformation.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaInformation.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaInformation_h
+#define RCTConvert_GCKMediaInformation_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaInformation)
+
++ (nonnull GCKMediaInformation *)GCKMediaInformation:(nonnull id)json;
++ (nonnull id)fromGCKMediaInformation:(nullable GCKMediaInformation *)info;
+
+@end
+
+#endif /* RCTConvert_GCKMediaInformation_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaInformation.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaInformation.m
@@ -1,11 +1,11 @@
-#import "RCTConvert+GCKAdBreakClipInfo.m"
-#import "RCTConvert+GCKAdBreakInfo.m"
-#import "RCTConvert+GCKMediaMetadata.m"
-#import "RCTConvert+GCKMediaStreamType.m"
-#import "RCTConvert+GCKMediaTrack.m"
-#import "RCTConvert+GCKMediaTextTrackStyle.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaInformation.h"
+
+#import "RCTConvert+GCKAdBreakClipInfo.h"
+#import "RCTConvert+GCKAdBreakInfo.h"
+#import "RCTConvert+GCKMediaMetadata.h"
+#import "RCTConvert+GCKMediaStreamType.h"
+#import "RCTConvert+GCKMediaTrack.h"
+#import "RCTConvert+GCKMediaTextTrackStyle.h"
 
 @implementation RCTConvert (GCKMediaInformation)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaLoadRequest.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaLoadRequest.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKMediaLoadRequest_h
+#define RCTConvert_GCKMediaLoadRequest_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaLoadRequest)
+
++ (nonnull GCKMediaLoadRequestData *)GCKMediaLoadRequestData:(nonnull id)json;
+
+@end
+
+#endif /* RCTConvert_GCKMediaLoadRequest_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaLoadRequest.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaLoadRequest.m
@@ -1,7 +1,7 @@
-#import "RCTConvert+GCKMediaInformation.m"
-#import "RCTConvert+GCKMediaQueueData.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaLoadRequest.h"
+
+#import "RCTConvert+GCKMediaInformation.h"
+#import "RCTConvert+GCKMediaQueueData.h"
 
 @implementation RCTConvert (GCKMediaLoadRequest)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaMetadata.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaMetadata.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaMetadata_h
+#define RCTConvert_GCKMediaMetadata_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaMetadata)
+
++ (nonnull GCKMediaMetadata *)GCKMediaMetadata:(nonnull id)json;
++ (nonnull id)fromGCKMediaMetadata:(nullable GCKMediaMetadata *)metadata;
+
+@end
+
+#endif /* RCTConvert_GCKMediaMetadata_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaMetadata.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaMetadata.m
@@ -1,8 +1,8 @@
-#import "RCTConvert+GCKMediaMetadataType.m"
-#import "RCTConvert+GCKImage.m"
-#import "RCTConvert+ISO8601Date.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaMetadata.h"
+
+#import "RCTConvert+GCKMediaMetadataType.h"
+#import "RCTConvert+GCKImage.h"
+#import "RCTConvert+ISO8601Date.h"
 
 @implementation RCTConvert (GCKMediaMetadata)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaMetadataType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaMetadataType.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaMetadataType_h
+#define RCTConvert_GCKMediaMetadataType_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaMetadataType)
+
++ (GCKMediaMetadataType)GCKMediaMetadataType:(id)json;
++ (nonnull id)fromGCKMediaMetadataType:(GCKMediaMetadataType)metadataType;
+
+@end
+
+#endif /* RCTConvert_GCKMediaMetadataType_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaMetadataType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaMetadataType.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaMetadataType)
 
-+ (GCKMediaMetadataType)GCKMediaMetadataType:(id)json;
++ (GCKMediaMetadataType)GCKMediaMetadataType:(nullable id)json;
 + (nonnull id)fromGCKMediaMetadataType:(GCKMediaMetadataType)metadataType;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaMetadataType.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaMetadataType.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaMetadataType.h"
 
 @implementation RCTConvert (GCKMediaMetadataType)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerIdleReason.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerIdleReason.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKMediaPlayerIdleReason_h
+#define RCTConvert_GCKMediaPlayerIdleReason_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaPlayerIdleReason)
+
++ (nonnull id)fromGCKMediaPlayerIdleReason:(GCKMediaPlayerIdleReason)reason;
+
+@end
+
+#endif /* RCTConvert_GCKMediaPlayerIdleReason_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerIdleReason.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerIdleReason.h
@@ -6,6 +6,7 @@
 
 @interface RCTConvert (GCKMediaPlayerIdleReason)
 
++ (GCKMediaPlayerIdleReason)GCKMediaPlayerIdleReason:(id)json;
 + (nonnull id)fromGCKMediaPlayerIdleReason:(GCKMediaPlayerIdleReason)reason;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerIdleReason.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerIdleReason.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaPlayerIdleReason)
 
-+ (GCKMediaPlayerIdleReason)GCKMediaPlayerIdleReason:(id)json;
++ (GCKMediaPlayerIdleReason)GCKMediaPlayerIdleReason:(nullable id)json;
 + (nonnull id)fromGCKMediaPlayerIdleReason:(GCKMediaPlayerIdleReason)reason;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerIdleReason.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerIdleReason.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaPlayerIdleReason.h"
 
 @implementation RCTConvert (GCKMediaPlayerIdleReason)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerState.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerState.h
@@ -6,6 +6,7 @@
 
 @interface RCTConvert (GCKMediaPlayerState)
 
++ (GCKMediaPlayerState)GCKMediaPlayerState:(id)json;
 + (nonnull id)fromGCKMediaPlayerState:(GCKMediaPlayerState)state;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerState.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerState.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaPlayerState)
 
-+ (GCKMediaPlayerState)GCKMediaPlayerState:(id)json;
++ (GCKMediaPlayerState)GCKMediaPlayerState:(nullable id)json;
 + (nonnull id)fromGCKMediaPlayerState:(GCKMediaPlayerState)state;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerState.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerState.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKMediaPlayerState_h
+#define RCTConvert_GCKMediaPlayerState_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaPlayerState)
+
++ (nonnull id)fromGCKMediaPlayerState:(GCKMediaPlayerState)state;
+
+@end
+
+#endif /* RCTConvert_GCKMediaPlayerState_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerState.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaPlayerState.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaPlayerState.h"
 
 @implementation RCTConvert (GCKMediaPlayerState)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueContainerMetadata.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueContainerMetadata.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaQueueContainerMetadata_h
+#define RCTConvert_GCKMediaQueueContainerMetadata_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaQueueContainerMetadata)
+
++ (GCKMediaQueueContainerMetadata *)GCKMediaQueueContainerMetadata:(id)json;
++ (nonnull id)fromGCKMediaQueueContainerMetadata:(nullable GCKMediaQueueContainerMetadata *)metadata;
+
+@end
+
+#endif /* RCTConvert_GCKMediaQueueContainerMetadata_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueContainerMetadata.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueContainerMetadata.m
@@ -1,8 +1,8 @@
-#import "RCTConvert+GCKMediaMetadata.m"
-#import "RCTConvert+GCKMediaQueueContainerType.m"
-#import "RCTConvert+GCKImage.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaQueueContainerMetadata.h"
+
+#import "RCTConvert+GCKMediaMetadata.h"
+#import "RCTConvert+GCKMediaQueueContainerType.h"
+#import "RCTConvert+GCKImage.h"
 
 @implementation RCTConvert (GCKMediaQueueContainerMetadata)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueContainerType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueContainerType.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaQueueContainerType)
 
-+ (GCKMediaQueueContainerType)GCKMediaQueueContainerType:(id)json;
++ (GCKMediaQueueContainerType)GCKMediaQueueContainerType:(nullable id)json;
 + (nonnull id)fromGCKMediaQueueContainerType:(GCKMediaQueueContainerType)type;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueContainerType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueContainerType.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaQueueContainerType_h
+#define RCTConvert_GCKMediaQueueContainerType_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaQueueContainerType)
+
++ (GCKMediaQueueContainerType)GCKMediaQueueContainerType:(id)json;
++ (nonnull id)fromGCKMediaQueueContainerType:(GCKMediaQueueContainerType)type;
+
+@end
+
+#endif /* RCTConvert_GCKMediaQueueContainerType_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueContainerType.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueContainerType.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaQueueContainerType.h"
 
 @implementation RCTConvert (GCKMediaQueueContainerType)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueData.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueData.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaQueueData_h
+#define RCTConvert_GCKMediaQueueData_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaQueueData)
+
++ (GCKMediaQueueData *)GCKMediaQueueData:(id)json;
++ (nonnull id)fromGCKMediaQueueData:(nullable GCKMediaQueueData *)data;
+
+@end
+
+#endif /* RCTConvert_GCKMediaQueueData_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueData.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueData.m
@@ -1,9 +1,9 @@
-#import "RCTConvert+GCKMediaQueueContainerMetadata.m"
-#import "RCTConvert+GCKMediaRepeatMode.m"
-#import "RCTConvert+GCKMediaQueueItem.m"
-#import "RCTConvert+GCKMediaQueueType.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaQueueData.h"
+
+#import "RCTConvert+GCKMediaQueueContainerMetadata.h"
+#import "RCTConvert+GCKMediaRepeatMode.h"
+#import "RCTConvert+GCKMediaQueueItem.h"
+#import "RCTConvert+GCKMediaQueueType.h"
 
 @implementation RCTConvert (GCKMediaQueueData)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueItem.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueItem.h
@@ -1,0 +1,15 @@
+#ifndef RCTConvert_GCKMediaQueueItem_h
+#define RCTConvert_GCKMediaQueueItem_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaQueueItem)
+
++ (NSArray<GCKMediaQueueItem *> *)GCKMediaQueueItemArray:(id)json;
++ (GCKMediaQueueItem *)GCKMediaQueueItem:(id)json;
++ (nonnull id)fromGCKMediaQueueItem:(nullable GCKMediaQueueItem *)item;
+
+@end
+
+#endif /* RCTConvert_GCKMediaQueueItem_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueItem.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueItem.m
@@ -1,6 +1,6 @@
-#import "RCTConvert+GCKMediaInformation.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaQueueItem.h"
+
+#import "RCTConvert+GCKMediaInformation.h"
 
 @implementation RCTConvert (GCKMediaQueueItem)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueType.h
@@ -1,0 +1,15 @@
+#ifndef RCTConvert_GCKMediaQueueType_h
+#define RCTConvert_GCKMediaQueueType_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaQueueType)
+
++ (GCKMediaQueueType)GCKMediaQueueType:(id)json;
++ (nonnull id)fromGCKMediaQueueType:(GCKMediaQueueType)type;
+
+@end
+
+
+#endif /* RCTConvert_GCKMediaQueueType_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueType.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaQueueType)
 
-+ (GCKMediaQueueType)GCKMediaQueueType:(id)json;
++ (GCKMediaQueueType)GCKMediaQueueType:(nullable id)json;
 + (nonnull id)fromGCKMediaQueueType:(GCKMediaQueueType)type;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueType.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaQueueType.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaQueueType.h"
 
 @implementation RCTConvert (GCKMediaQueueType)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaRepeatMode.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaRepeatMode.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaRepeatMode)
 
-+ (GCKMediaRepeatMode)GCKMediaRepeatMode:(id)json;
++ (GCKMediaRepeatMode)GCKMediaRepeatMode:(nullable id)json;
 + (nonnull id)fromGCKMediaRepeatMode:(GCKMediaRepeatMode)mode;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaRepeatMode.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaRepeatMode.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaRepeatMode_h
+#define RCTConvert_GCKMediaRepeatMode_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaRepeatMode)
+
++ (GCKMediaRepeatMode)GCKMediaRepeatMode:(id)json;
++ (nonnull id)fromGCKMediaRepeatMode:(GCKMediaRepeatMode)mode;
+
+@end
+
+#endif /* RCTConvert_GCKMediaRepeatMode_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaRepeatMode.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaRepeatMode.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaRepeatMode.h"
 
 @implementation RCTConvert (GCKMediaRepeatMode)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaResumeState.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaResumeState.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaResumeState_h
+#define RCTConvert_GCKMediaResumeState_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaResumeState)
+
++ (GCKMediaResumeState)GCKMediaResumeState:(id)json;
++ (nonnull id)fromGCKMediaResumeState:(GCKMediaResumeState)state;
+
+@end
+
+#endif /* RCTConvert_GCKMediaResumeState_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaResumeState.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaResumeState.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaResumeState)
 
-+ (GCKMediaResumeState)GCKMediaResumeState:(id)json;
++ (GCKMediaResumeState)GCKMediaResumeState:(nullable id)json;
 + (nonnull id)fromGCKMediaResumeState:(GCKMediaResumeState)state;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaResumeState.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaResumeState.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaResumeState.h"
 
 @implementation RCTConvert (GCKMediaResumeState)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaSeekOptions.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaSeekOptions.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKMediaSeekOptions_h
+#define RCTConvert_GCKMediaSeekOptions_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaSeekOptions)
+
++ (GCKMediaSeekOptions *)GCKMediaSeekOptions:(id)json;
+
+@end
+
+#endif /* RCTConvert_GCKMediaSeekOptions_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaSeekOptions.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaSeekOptions.m
@@ -1,6 +1,6 @@
-#import "RCTConvert+GCKMediaResumeState.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaSeekOptions.h"
+
+#import "RCTConvert+GCKMediaResumeState.h"
 
 @implementation RCTConvert (GCKMediaSeekOptions)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaStatus.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaStatus.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKMediaStatus_h
+#define RCTConvert_GCKMediaStatus_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaStatus)
+
++ (nonnull id)fromGCKMediaStatus:(nullable GCKMediaStatus *)status;
+
+@end
+
+#endif /* RCTConvert_GCKMediaStatus_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaStatus.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaStatus.m
@@ -1,12 +1,12 @@
-#import "RCTConvert+GCKMediaPlayerIdleReason.m"
-#import "RCTConvert+GCKMediaPlayerState.m"
-#import "RCTConvert+GCKMediaInformation.m"
-#import "RCTConvert+GCKMediaRepeatMode.m"
-#import "RCTConvert+GCKMediaQueueItem.m"
-#import "RCTConvert+GCKVideoInfo.m"
-#import "RCTConvert+GCKAdBreakStatus.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaStatus.h"
+
+#import "RCTConvert+GCKMediaPlayerIdleReason.h"
+#import "RCTConvert+GCKMediaPlayerState.h"
+#import "RCTConvert+GCKMediaInformation.h"
+#import "RCTConvert+GCKMediaRepeatMode.h"
+#import "RCTConvert+GCKMediaQueueItem.h"
+#import "RCTConvert+GCKVideoInfo.h"
+#import "RCTConvert+GCKAdBreakStatus.h"
 
 @implementation RCTConvert (GCKMediaStatus)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaStreamType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaStreamType.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaStreamType_h
+#define RCTConvert_GCKMediaStreamType_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaStreamType)
+
++ (GCKMediaStreamType)GCKMediaStreamType:(id)json;
++ (nonnull id)fromGCKMediaStreamType:(GCKMediaStreamType)streamType;
+
+@end
+
+#endif /* RCTConvert_GCKMediaStreamType_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaStreamType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaStreamType.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaStreamType)
 
-+ (GCKMediaStreamType)GCKMediaStreamType:(id)json;
++ (GCKMediaStreamType)GCKMediaStreamType:(nullable id)json;
 + (nonnull id)fromGCKMediaStreamType:(GCKMediaStreamType)streamType;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaStreamType.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaStreamType.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaStreamType.h"
 
 @implementation RCTConvert (GCKMediaStreamType)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyle.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyle.h
@@ -1,0 +1,16 @@
+#ifndef RCTConvert_GCKMediaTextTrackStyle_h
+#define RCTConvert_GCKMediaTextTrackStyle_h
+
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaTextTrackStyle)
+
++ (GCKMediaTextTrackStyle *)GCKMediaTextTrackStyle:(id)json;
++ (nonnull id)fromGCKMediaTextTrackStyle:(nullable GCKMediaTextTrackStyle *)style;
+
+@end
+
+
+#endif /* RCTConvert_GCKMediaTextTrackStyle_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyle.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyle.m
@@ -1,10 +1,10 @@
-#import "RCTConvert+GCKColor.m"
-#import "RCTConvert+GCKMediaTextTrackStyleEdgeType.m"
-#import "RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.m"
-#import "RCTConvert+GCKMediaTextTrackStyleFontStyle.m"
-#import "RCTConvert+GCKMediaTextTrackStyleWindowType.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaTextTrackStyle.h"
+
+#import "RCTConvert+GCKColor.h"
+#import "RCTConvert+GCKMediaTextTrackStyleEdgeType.h"
+#import "RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.h"
+#import "RCTConvert+GCKMediaTextTrackStyleFontStyle.h"
+#import "RCTConvert+GCKMediaTextTrackStyleWindowType.h"
 
 @implementation RCTConvert (GCKMediaTextTrackStyle)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleEdgeType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleEdgeType.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaTextTrackStyleEdgeType)
 
-+ (GCKMediaTextTrackStyleEdgeType)GCKMediaTextTrackStyleEdgeType:(id)json;
++ (GCKMediaTextTrackStyleEdgeType)GCKMediaTextTrackStyleEdgeType:(nullable id)json;
 + (nonnull id)fromGCKMediaTextTrackStyleEdgeType:(GCKMediaTextTrackStyleEdgeType)type;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleEdgeType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleEdgeType.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaTextTrackStyleEdgeType_h
+#define RCTConvert_GCKMediaTextTrackStyleEdgeType_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaTextTrackStyleEdgeType)
+
++ (GCKMediaTextTrackStyleEdgeType)GCKMediaTextTrackStyleEdgeType:(id)json;
++ (nonnull id)fromGCKMediaTextTrackStyleEdgeType:(GCKMediaTextTrackStyleEdgeType)type;
+
+@end
+
+#endif /* RCTConvert_GCKMediaTextTrackStyleEdgeType_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleEdgeType.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleEdgeType.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaTextTrackStyleEdgeType.h"
 
 @implementation RCTConvert (GCKMediaTextTrackStyleEdgeType)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.h
@@ -1,0 +1,15 @@
+#ifndef RCTConvert_GCKMediaTextTrackStyleFontGenericFamily_h
+#define RCTConvert_GCKMediaTextTrackStyleFontGenericFamily_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaTextTrackStyleFontGenericFamily)
+
++ (GCKMediaTextTrackStyleFontGenericFamily)GCKMediaTextTrackStyleFontGenericFamily:(id)json;
++ (nonnull id)fromGCKMediaTextTrackStyleFontGenericFamily:
+(GCKMediaTextTrackStyleFontGenericFamily)type;
+
+@end
+
+#endif /* RCTConvert_GCKMediaTextTrackStyleFontGenericFamily_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaTextTrackStyleFontGenericFamily)
 
-+ (GCKMediaTextTrackStyleFontGenericFamily)GCKMediaTextTrackStyleFontGenericFamily:(id)json;
++ (GCKMediaTextTrackStyleFontGenericFamily)GCKMediaTextTrackStyleFontGenericFamily:(nullable id)json;
 + (nonnull id)fromGCKMediaTextTrackStyleFontGenericFamily:
 (GCKMediaTextTrackStyleFontGenericFamily)type;
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaTextTrackStyleFontGenericFamily.h"
 
 @implementation RCTConvert (GCKMediaTextTrackStyleFontGenericFamily)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontStyle.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontStyle.h
@@ -6,6 +6,7 @@
 
 @interface RCTConvert (GCKMediaTextTrackStyleFontStyle)
 
++ (GCKMediaTextTrackStyleFontStyle)GCKMediaTextTrackStyleFontStyle:(id)json;
 + (nonnull id)fromGCKMediaTextTrackStyleFontStyle:
 (GCKMediaTextTrackStyleFontStyle)type;
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontStyle.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontStyle.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaTextTrackStyleFontStyle_h
+#define RCTConvert_GCKMediaTextTrackStyleFontStyle_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaTextTrackStyleFontStyle)
+
++ (nonnull id)fromGCKMediaTextTrackStyleFontStyle:
+(GCKMediaTextTrackStyleFontStyle)type;
+
+@end
+
+#endif /* RCTConvert_GCKMediaTextTrackStyleFontStyle_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontStyle.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontStyle.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaTextTrackStyleFontStyle)
 
-+ (GCKMediaTextTrackStyleFontStyle)GCKMediaTextTrackStyleFontStyle:(id)json;
++ (GCKMediaTextTrackStyleFontStyle)GCKMediaTextTrackStyleFontStyle:(nullable id)json;
 + (nonnull id)fromGCKMediaTextTrackStyleFontStyle:
 (GCKMediaTextTrackStyleFontStyle)type;
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontStyle.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleFontStyle.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaTextTrackStyleFontStyle.h"
 
 @implementation RCTConvert (GCKMediaTextTrackStyleFontStyle)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleWindowType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleWindowType.h
@@ -1,0 +1,15 @@
+#ifndef RCTConvert_GCKMediaTextTrackStyleWindowType_h
+#define RCTConvert_GCKMediaTextTrackStyleWindowType_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaTextTrackStyleWindowType)
+
++ (GCKMediaTextTrackStyleWindowType)GCKMediaTextTrackStyleWindowType:(id)json;
++ (nonnull id)fromGCKMediaTextTrackStyleWindowType:
+(GCKMediaTextTrackStyleWindowType)type;
+
+@end
+
+#endif /* RCTConvert_GCKMediaTextTrackStyleWindowType_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleWindowType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleWindowType.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaTextTrackStyleWindowType)
 
-+ (GCKMediaTextTrackStyleWindowType)GCKMediaTextTrackStyleWindowType:(id)json;
++ (GCKMediaTextTrackStyleWindowType)GCKMediaTextTrackStyleWindowType:(nullable id)json;
 + (nonnull id)fromGCKMediaTextTrackStyleWindowType:
 (GCKMediaTextTrackStyleWindowType)type;
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleWindowType.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackStyleWindowType.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaTextTrackStyleWindowType.h"
 
 @implementation RCTConvert (GCKMediaTextTrackStyleWindowType)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackSubtype.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackSubtype.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaTextTrackSubtype)
 
-+ (GCKMediaTextTrackSubtype)GCKMediaTextTrackSubtype:(id)json;
++ (GCKMediaTextTrackSubtype)GCKMediaTextTrackSubtype:(nullable id)json;
 + (nonnull id)fromGCKMediaTextTrackSubtype:(GCKMediaTextTrackSubtype)subtype;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackSubtype.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackSubtype.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaTextTrackSubtype_h
+#define RCTConvert_GCKMediaTextTrackSubtype_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaTextTrackSubtype)
+
++ (GCKMediaTextTrackSubtype)GCKMediaTextTrackSubtype:(id)json;
++ (nonnull id)fromGCKMediaTextTrackSubtype:(GCKMediaTextTrackSubtype)subtype;
+
+@end
+
+#endif /* RCTConvert_GCKMediaTextTrackSubtype_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackSubtype.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTextTrackSubtype.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaTextTrackSubtype.h"
 
 @implementation RCTConvert (GCKMediaTextTrackSubtype)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTrack.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTrack.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaTrack_h
+#define RCTConvert_GCKMediaTrack_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaTrack)
+
++ (nonnull GCKMediaTrack *)GCKMediaTrack:(nonnull id)json;
++ (nonnull id)fromGCKMediaTrack:(nullable GCKMediaTrack *)track;
+
+@end
+
+#endif /* RCTConvert_GCKMediaTrack_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTrack.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTrack.m
@@ -1,7 +1,7 @@
-#import "RCTConvert+GCKMediaTextTrackSubtype.m"
-#import "RCTConvert+GCKMediaTrackType.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaTrack.h"
+
+#import "RCTConvert+GCKMediaTextTrackSubtype.h"
+#import "RCTConvert+GCKMediaTrackType.h"
 
 @implementation RCTConvert (GCKMediaTrack)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTrackType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTrackType.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKMediaTrackType_h
+#define RCTConvert_GCKMediaTrackType_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKMediaTrackType)
+
++ (GCKMediaTrackType)GCKMediaTrackType:(id)json;
++ (nonnull id)fromGCKMediaTrackType:(GCKMediaTrackType)trackType;
+
+@end
+
+#endif /* RCTConvert_GCKMediaTrackType_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTrackType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTrackType.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKMediaTrackType)
 
-+ (GCKMediaTrackType)GCKMediaTrackType:(id)json;
++ (GCKMediaTrackType)GCKMediaTrackType:(nullable id)json;
 + (nonnull id)fromGCKMediaTrackType:(GCKMediaTrackType)trackType;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKMediaTrackType.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKMediaTrackType.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKMediaTrackType.h"
 
 @implementation RCTConvert (GCKMediaTrackType)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKRemoteMediaClient.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKRemoteMediaClient.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKRemoteMediaClient_h
+#define RCTConvert_GCKRemoteMediaClient_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKRemoteMediaClient)
+
++ (nonnull id)fromGCKRemoteMediaClient:(nullable GCKRemoteMediaClient *)client;
+
+@end
+
+#endif /* RCTConvert_GCKRemoteMediaClient_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKRemoteMediaClient.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKRemoteMediaClient.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKRemoteMediaClient.h"
 
 @implementation RCTConvert (GCKRemoteMediaClient)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKStandbyStatus.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKStandbyStatus.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKStandbyStatus_h
+#define RCTConvert_GCKStandbyStatus_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKStandbyStatus)
+
++ (nonnull id)fromGCKStandbyStatus:(GCKStandbyStatus)status;
+
+@end
+
+#endif /* RCTConvert_GCKStandbyStatus_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKStandbyStatus.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKStandbyStatus.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKStandbyStatus.h"
 
 @implementation RCTConvert (GCKStandbyStatus)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfo.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfo.h
@@ -1,0 +1,14 @@
+#ifndef RCTConvert_GCKVideoInfo_h
+#define RCTConvert_GCKVideoInfo_h
+
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKVideoInfo)
+
++ (nonnull id)fromGCKVideoInfo:(nullable GCKVideoInfo *)video;
+
+@end
+
+#endif /* RCTConvert_GCKVideoInfo_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfo.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfo.m
@@ -1,6 +1,6 @@
-#import "RCTConvert+GCKVideoInfoHDRType.m"
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKVideoInfo.h"
+
+#import "RCTConvert+GCKVideoInfoHDRType.h"
 
 @implementation RCTConvert (GCKVideoInfo)
 

--- a/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfoHDRType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfoHDRType.h
@@ -6,6 +6,7 @@
 
 @interface RCTConvert (GCKVideoInfoHDRType)
 
++ (GCKVideoInfoHDRType)GCKVideoInfoHDRType:(id)json;
 + (nonnull id)fromGCKVideoInfoHDRType:(GCKVideoInfoHDRType)type;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfoHDRType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfoHDRType.h
@@ -1,0 +1,13 @@
+#ifndef RCTConvert_GCKVideoInfoHDRType_h
+#define RCTConvert_GCKVideoInfoHDRType_h
+
+#import <GoogleCast/GoogleCast.h>
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (GCKVideoInfoHDRType)
+
++ (nonnull id)fromGCKVideoInfoHDRType:(GCKVideoInfoHDRType)type;
+
+@end
+
+#endif /* RCTConvert_GCKVideoInfoHDRType_h */

--- a/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfoHDRType.h
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfoHDRType.h
@@ -6,7 +6,7 @@
 
 @interface RCTConvert (GCKVideoInfoHDRType)
 
-+ (GCKVideoInfoHDRType)GCKVideoInfoHDRType:(id)json;
++ (GCKVideoInfoHDRType)GCKVideoInfoHDRType:(nullable id)json;
 + (nonnull id)fromGCKVideoInfoHDRType:(GCKVideoInfoHDRType)type;
 
 @end

--- a/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfoHDRType.m
+++ b/ios/RNGoogleCast/types/RCTConvert+GCKVideoInfoHDRType.m
@@ -1,5 +1,4 @@
-#import <GoogleCast/GoogleCast.h>
-#import <React/RCTConvert.h>
+#import "RCTConvert+GCKVideoInfoHDRType.h"
 
 @implementation RCTConvert (GCKVideoInfoHDRType)
 

--- a/ios/RNGoogleCast/types/RCTConvert+ISO8601Date.h
+++ b/ios/RNGoogleCast/types/RCTConvert+ISO8601Date.h
@@ -1,0 +1,12 @@
+#ifndef RCTConvert_ISO8601Date_h
+#define RCTConvert_ISO8601Date_h
+
+#import <React/RCTConvert.h>
+
+@interface RCTConvert (ISO8601Date)
+
++ (NSDate *)ISO8601Date:(id)json;
+
+@end
+
+#endif /* RCTConvert_ISO8601Date_h */

--- a/ios/RNGoogleCast/types/RCTConvert+ISO8601Date.m
+++ b/ios/RNGoogleCast/types/RCTConvert+ISO8601Date.m
@@ -1,4 +1,4 @@
-#import <React/RCTConvert.h>
+#import "RCTConvert+ISO8601Date.h"
 
 @implementation RCTConvert (ISO8601Date)
 


### PR DESCRIPTION
### Background
We are getting a lot of linker warnings from iOS react-native-google-cast.
<img src='https://user-images.githubusercontent.com/41613812/107552983-de362680-6bdc-11eb-9cf2-da502955cf6b.png' width=400px  />
I've tried to search the reason for these warnings and seems like the cause is not creating a proper header file for each category implementation in **`types`** folder.

### How to test the issue?
1. Open **`playground`** folder. Run **`yarn install`**.
2. Go to **`ios`** and run **`pod install`**.
3. Open the Xcode project.
4. Build the project. 
5. See the warnings.

### What has been done?
1. I've created a header file for each implementation file for **`types`** folder.
2. I've imported header files instead of **`.m`** files.

### How to test the changes?
1. Open **`playground`** folder. Run **`yarn install`**.
2. Go to **`ios`** and run **`pod install`**.
3. Open the Xcode project.
4. Build the project. 
5. Check that no more warnings are coming from **`react-native-google-cast`** or at least from **`types`** folder files 😅.
6. Check that I've used the right methods declarations in the header files.
